### PR TITLE
Se prerellena el email del signup del newsletter si viene la cookie del email

### DIFF
--- a/layouts/shortcodes/newsletter_fintual_signup.html
+++ b/layouts/shortcodes/newsletter_fintual_signup.html
@@ -34,6 +34,10 @@
     width: 100%;
   }
 
+  .newsletter-card__email-input--prefilled {
+    display: none;
+  }
+
   .newsletter-card__button {
     background-image: linear-gradient(270deg, #3985ee 0%, #005ad6 100%);
     border-radius: 18px;
@@ -71,10 +75,35 @@
 </style>
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <script>
- function onSubmit(token) {
-   document.getElementById('newsletter-signup-form').submit();
-   document.querySelector('.newsletter-card').classList.add('newsletter-card--submitted')
- }
+function onSubmit(token) {
+  document.getElementById('newsletter-signup-form').submit();
+  document.querySelector('.newsletter-card').classList.add('newsletter-card--submitted')
+}
+
+function getCookie(cname) {
+  const name = cname + "=";
+  const decodedCookie = decodeURIComponent(document.cookie);
+  const ca = decodedCookie.split(';');
+  for(var i = 0; i <ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) == ' ') {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length);
+    }
+  }
+  return '';
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  const email = getCookie('email');
+  if (!!email) {
+    const emailInput = document.querySelector('input[name="user[email]"]');
+    emailInput.classList.add('newsletter-card__email-input--prefilled')
+    emailInput.value = email;
+  }
+});
 </script>
 
 <div class="newsletter-card">


### PR DESCRIPTION
Se revisa en conjunto con https://github.com/platanus/fintual-rails/pull/15763

### Cómo probar?

- Monta los dos servidores.
- Agrega `{{< newsletter_fintual_signup >}} en algún post, yo siempre pruebo con `content/post/que-ha-pasado-con-las-inversiones-en-fintual-durante-la-pandemia.md`. Deberías ver que te pide el email.
- Ahora entra a lvh.me:3000 e inicia sesión (si ya tenías la sesión iniciada, cierra y vuelve a entrar), esto va a crear la cookie `email`.
- Ahora anda a edu.lvh.me:1313, entra al post (ojo con que no te mueva a localhost) y deberías ver que se prerellena el email y no te lo pide (puedes comprobar en consola con `document.querySelector('input[name="user[email]"]').value`.